### PR TITLE
Fix ClassNotFoundError in Contao 5

### DIFF
--- a/src/Form/FormRadioButton.php
+++ b/src/Form/FormRadioButton.php
@@ -10,7 +10,18 @@ declare(strict_types=1);
 
 namespace InspiredMinds\ContaoExtendedFormFieldsBundle\Form;
 
-class FormRadioButton extends \Contao\FormRadioButton
+
+if (class_exists(\Contao\FormRadioButton::class)) {
+    class FormRadioButtonBaseClass extends \Contao\FormRadioButton
+    {
+    }
+} else {
+    class FormRadioButtonBaseClass extends \Contao\FormRadio
+    {
+    }
+}
+
+class FormRadioButton extends FormRadioButtonBaseClass
 {
     public function parse($arrAttributes = null)
     {


### PR DESCRIPTION
FormRadioButton was renamed to FormRadio in Contao 5

This PR fixes the following error

```
Symfony\Component\ErrorHandler\Error\ClassNotFoundError:
Attempted to load class "FormRadioButton" from namespace "Contao".
Did you forget a "use" statement for another namespace?

  at vendor/inspiredminds/contao-extended-form-fields/src/Form/FormRadioButton.php:13
  at include()
     (vendor/symfony/error-handler/DebugClassLoader.php:296)
  at Symfony\Component\ErrorHandler\DebugClassLoader->loadClass()
  at class_exists()
     (vendor/contao/core-bundle/contao/forms/Form.php:218)
  at Contao\Form->compile()
     (vendor/contao/core-bundle/contao/classes/Hybrid.php:231)
  at Contao\Hybrid->generate()
     (vendor/contao/core-bundle/contao/forms/Form.php:107)
  at Contao\Form->generate()
     (vendor/contao/core-bundle/contao/library/Contao/Controller.php:673)
  at Contao\Controller::getForm()
     (vendor/contao/core-bundle/src/InsertTag/Resolver/LegacyInsertTag.php:289)
  at Contao\CoreBundle\InsertTag\Resolver\LegacyInsertTag->__invoke()
     (vendor/contao/core-bundle/src/InsertTag/InsertTagParser.php:420)
  at Contao\CoreBundle\InsertTag\InsertTagParser->renderSubscription()
     (vendor/contao/core-bundle/src/InsertTag/InsertTagParser.php:392)
  at Contao\CoreBundle\InsertTag\InsertTagParser->executeReplace()
     (vendor/contao/core-bundle/src/InsertTag/InsertTagParser.php:133)
  at Contao\CoreBundle\InsertTag\InsertTagParser->replace()
     (templates/x/rsce_step_by_step_form.html5:11)
  at include('/x/templates/x/rsce_step_by_step_form.html5')
     (vendor/contao/core-bundle/contao/library/Contao/TemplateInheritance.php:109)
  at Contao\Template->inherit()
     (vendor/contao/core-bundle/contao/library/Contao/Template.php:287)
  at Contao\Template->parse()
     (vendor/contao/core-bundle/contao/classes/FrontendTemplate.php:43)
  at Contao\FrontendTemplate->parse()
     (vendor/contao/core-bundle/contao/elements/ContentElement.php:272)
  at Contao\ContentElement->generate()
     (vendor/madeyourday/contao-rocksolid-custom-elements/src/Element/CustomElement.php:51)
  at MadeYourDay\RockSolidCustomElements\Element\CustomElement->generate()
     (vendor/contao/core-bundle/contao/library/Contao/Controller.php:604)
  at Contao\Controller::getContentElement()
     (vendor/contao/core-bundle/contao/modules/ModuleArticle.php:191)
  at Contao\ModuleArticle->compile()
     (vendor/contao/core-bundle/contao/modules/Module.php:213)
  at Contao\Module->generate()
     (vendor/contao/core-bundle/contao/modules/ModuleArticle.php:69)
  at Contao\ModuleArticle->generate()
     (vendor/contao/core-bundle/contao/library/Contao/Controller.php:499)
  at Contao\Controller::getArticle()
     (vendor/contao/core-bundle/contao/library/Contao/Controller.php:364)
  at Contao\Controller::getFrontendModule()
     (vendor/contao/core-bundle/contao/pages/PageRegular.php:171)
  at Contao\PageRegular->prepare()
     (vendor/contao/core-bundle/contao/pages/PageRegular.php:46)
  at Contao\PageRegular->getResponse()
     (vendor/contao/core-bundle/contao/controllers/FrontendIndex.php:66)
  at Contao\FrontendIndex->renderPage()
     (vendor/symfony/http-kernel/HttpKernel.php:181)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw()
     (vendor/symfony/http-kernel/HttpKernel.php:76)
  at Symfony\Component\HttpKernel\HttpKernel->handle()
     (vendor/symfony/http-kernel/Kernel.php:197)
  at Symfony\Component\HttpKernel\Kernel->handle()
     (public/index.php:44)  ```